### PR TITLE
Updated Dockerfile

### DIFF
--- a/identidock/Dockerfile
+++ b/identidock/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.4
 
 RUN groupadd -r uwsgi && useradd -r -g uwsgi uwsgi
-RUN pip install Flask==0.10.1 uWSGI==2.0.8
+RUN pip install Flask==1.0.2 uWSGI==2.0.13.1 requests==2.19.1
 WORKDIR /app
 COPY app /app
 COPY cmd.sh /


### PR DESCRIPTION
The Docker image did not build successfully using uWSGI == 2.08, the examples in the book worked fine for me after updating the versions of uWSGI and Flask.