### PR TITLE
Fix warring message

### DIFF
--- a/identidock/Dockerfile
+++ b/identidock/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.4
+FROM python:3.7
 
 RUN groupadd -r uwsgi && useradd -r -g uwsgi uwsgi
 RUN pip install Flask==0.10.1 uWSGI==2.0.8


### PR DESCRIPTION
Python 3.4 is old version already.
Changing Python version fix warning message.